### PR TITLE
feat: SSG/SSRハイブリッド構成に切り替え

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -3,5 +3,5 @@ import { defineConfig } from "astro/config";
 
 export default defineConfig({
   output: "server",
-  adapter: cloudflare(),
+  adapter: cloudflare({ prerenderEnvironment: "node" }),
 });

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import Container from "../components/Container.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
 

--- a/src/pages/note/index.astro
+++ b/src/pages/note/index.astro
@@ -1,6 +1,4 @@
 ---
-export const prerender = false;
-
 import NoteList from "../../components/NoteList.astro";
 import Container from "../../components/Container.astro";
 import BaseLayout from "../../layouts/BaseLayout.astro";

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import Container from "../../components/Container.astro";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 ---


### PR DESCRIPTION
## Summary

- `output: \"server\"` をベースに、静的ページ（`/`、`/projects`）に `export const prerender = true` を追加してSSG化
- `note/index.astro` の不要な `prerender = false` を削除（`output: \"server\"` のデフォルトがSSRなので明示不要）
- `@astrojs/cloudflare` v13 のハイブリッドモード時に `kv_namespaces` が重複するバグを `prerenderEnvironment: \"node\"` で回避

## 背景

`@astrojs/cloudflare` v13 では `prerenderWorker` が `entryWorkerConfig` を spread で引き継ぐため、`wrangler.jsonc` に定義した KV バインディングが `.prerender/wrangler.json` に重複して書き込まれビルドが失敗する。`prerenderEnvironment: \"node\"` を指定すると prerender が Node.js で実行されるため `.prerender/wrangler.json` が生成されず問題が回避される。ビルド時のみ Node を使用し、実行時は引き続き Cloudflare Workers で動作する。

## Test plan

- [x] `pnpm build` が成功する
- [x] `/`、`/projects` が静的HTML として出力される
- [x] `/note`、`/api/*` がSSRとして動作する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized prerendering configuration for the main index and projects pages to improve site performance and load times.
  * Updated Cloudflare deployment adapter settings to ensure optimal handling of static page generation.
  * Adjusted build-time page generation behavior for the notes section to align with the new rendering strategy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/H-ymt/hymt/pull/42)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->