### PR TITLE
feat: Resendを使ったお問い合わせフォームを追加

### DIFF
--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -6,4 +6,5 @@ interface CloudflareEnv {
   GITHUB_TOKEN?: string;
   ZENN_USER?: string;
   RESEND_API_KEY?: string;
+  TURNSTILE_SECRET_KEY?: string;
 }

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -5,4 +5,5 @@ interface CloudflareEnv {
   GITHUB_USERNAME?: string;
   GITHUB_TOKEN?: string;
   ZENN_USER?: string;
+  RESEND_API_KEY?: string;
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "@astrojs/cloudflare": "^13.5.0",
-    "astro": "^6.3.1"
+    "astro": "^6.3.1",
+    "resend": "^6.12.3"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "tsx scripts/fetch-knowledge.ts && tsx scripts/sync-local-kv.ts && astro dev",
     "build": "tsx scripts/fetch-knowledge.ts && astro build && tsx scripts/dedup-wrangler.ts",
-    "preview": "astro build && wrangler dev --config dist/server/wrangler.json",
+    "preview": "astro build && tsx scripts/dedup-wrangler.ts && wrangler dev --config dist/server/wrangler.json",
     "lint": "biome check .",
     "lint:fix": "biome check --fix .",
     "format": "biome format --fix .",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       astro:
         specifier: ^6.3.1
         version: 6.3.1(@types/node@24.12.2)(aws4fetch@1.0.20)(rollup@4.60.3)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)
+      resend:
+        specifier: ^6.12.3
+        version: 6.12.3
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.9
@@ -900,6 +903,9 @@ packages:
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -1206,6 +1212,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -1591,6 +1600,9 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1669,6 +1681,15 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resend@6.12.3:
+    resolution: {integrity: sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -1727,6 +1748,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -1746,6 +1770,9 @@ packages:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
     hasBin: true
+
+  svix@1.92.2:
+    resolution: {integrity: sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==}
 
   terser@5.16.9:
     resolution: {integrity: sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==}
@@ -2810,6 +2837,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.15': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -3231,6 +3260,8 @@ snapshots:
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -3833,6 +3864,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  postal-mime@2.7.4: {}
+
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
@@ -3934,6 +3967,11 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  resend@6.12.3:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.92.2
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -4056,6 +4094,11 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -4082,6 +4125,10 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
       sax: 1.6.0
+
+  svix@1.92.2:
+    dependencies:
+      standardwebhooks: 1.0.0
 
   terser@5.16.9:
     dependencies:

--- a/scripts/fetch-knowledge.ts
+++ b/scripts/fetch-knowledge.ts
@@ -8,10 +8,9 @@ import type { KnowledgeEntry } from "../src/lib/types";
 import { ensureUniqueSlugs, timeIt, toSinceIso } from "../src/lib/utils";
 
 // 環境変数を読み込む
-const envLocalPath = join(process.cwd(), ".env.local");
-const envPath = join(process.cwd(), ".env");
-config({ path: envLocalPath });
-config({ path: envPath }); // .envファイルも読み込む
+config({ path: join(process.cwd(), ".env.local") });
+config({ path: join(process.cwd(), ".env") });
+config({ path: join(process.cwd(), ".dev.vars") });
 
 interface Env {
   GITHUB_USERNAME?: string;

--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -4,6 +4,7 @@ const pathname = Astro.url.pathname;
 const items = [
   { name: "Home", link: "/" },
   { name: "Note", link: "/note" },
+  { name: "Contact", link: "/contact" },
   { name: "Projects", link: "https://portfolio.h-ymt.dev/" },
   { name: "Resume", link: "https://portfolio.h-ymt.dev/resume" },
 ];

--- a/src/lib/utils/cloudflare.ts
+++ b/src/lib/utils/cloudflare.ts
@@ -8,6 +8,10 @@ export function getResendApiKey(): string | undefined {
   return (env as CloudflareEnv).RESEND_API_KEY;
 }
 
+export function getTurnstileSecretKey(): string | undefined {
+  return (env as CloudflareEnv).TURNSTILE_SECRET_KEY;
+}
+
 export function getFetchKnowledgeEnv(): {
   GITHUB_USERNAME?: string;
   GITHUB_TOKEN?: string;

--- a/src/lib/utils/cloudflare.ts
+++ b/src/lib/utils/cloudflare.ts
@@ -4,6 +4,10 @@ export function getKnowledgeKV(): KVNamespace | undefined {
   return (env as CloudflareEnv).KNOWLEDGE_KV;
 }
 
+export function getResendApiKey(): string | undefined {
+  return (env as CloudflareEnv).RESEND_API_KEY;
+}
+
 export function getFetchKnowledgeEnv(): {
   GITHUB_USERNAME?: string;
   GITHUB_TOKEN?: string;

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -72,7 +72,7 @@ export const POST: APIRoute = async ({ request }) => {
 
   const resend = new Resend(apiKey);
   const { error } = await resend.emails.send({
-    from: "contact@h-ymt.dev",
+    from: "noreply@h-ymt.dev",
     to: ["y.handai1272@gmail.com"],
     subject: `Contact from ${result.data.name}`,
     replyTo: result.data.email,

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -1,0 +1,70 @@
+import type { APIRoute } from "astro";
+import { Resend } from "resend";
+import { getResendApiKey } from "../../lib/utils/cloudflare";
+
+interface FormFields {
+  name: string;
+  email: string;
+  message: string;
+}
+
+function validateForm(
+  data: Record<string, string>,
+): { valid: true; data: FormFields } | { valid: false; error: string } {
+  const { name, email, message } = data;
+
+  if (!name?.trim() || !email?.trim() || !message?.trim()) {
+    return { valid: false, error: "All fields are required." };
+  }
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return { valid: false, error: "Please enter a valid email address." };
+  }
+
+  return { valid: true, data: { name: name.trim(), email: email.trim(), message: message.trim() } };
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  const formData = await request.formData();
+  const raw = {
+    name: String(formData.get("name") ?? ""),
+    email: String(formData.get("email") ?? ""),
+    message: String(formData.get("message") ?? ""),
+  };
+
+  const result = validateForm(raw);
+  if (!result.valid) {
+    return new Response(JSON.stringify({ success: false, error: result.error }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const apiKey = getResendApiKey();
+  if (!apiKey) {
+    return new Response(
+      JSON.stringify({ success: false, error: "Mail service is not configured." }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const resend = new Resend(apiKey);
+  const { error } = await resend.emails.send({
+    from: "contact@h-ymt.dev",
+    to: ["glanz.web.creative@gmail.com"],
+    subject: `Contact from ${result.data.name}`,
+    replyTo: result.data.email,
+    text: `Name: ${result.data.name}\nEmail: ${result.data.email}\n\n${result.data.message}`,
+  });
+
+  if (error) {
+    return new Response(
+      JSON.stringify({ success: false, error: "Failed to send your message. Please try again later." }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  return new Response(JSON.stringify({ success: true }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro";
 import { Resend } from "resend";
-import { getResendApiKey } from "../../lib/utils/cloudflare";
+import { getResendApiKey, getTurnstileSecretKey } from "../../lib/utils/cloudflare";
 
 interface FormFields {
   name: string;
@@ -26,6 +26,28 @@ function validateForm(
 
 export const POST: APIRoute = async ({ request }) => {
   const formData = await request.formData();
+
+  const token = String(formData.get("cf-turnstile-response") ?? "");
+  const secretKey = getTurnstileSecretKey();
+  if (!secretKey) {
+    return new Response(
+      JSON.stringify({ success: false, error: "CAPTCHA service is not configured." }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+  const verifyRes = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ secret: secretKey, response: token }),
+  });
+  const verifyData = await verifyRes.json() as { success: boolean };
+  if (!verifyData.success) {
+    return new Response(
+      JSON.stringify({ success: false, error: "CAPTCHA verification failed. Please try again." }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
   const raw = {
     name: String(formData.get("name") ?? ""),
     email: String(formData.get("email") ?? ""),
@@ -51,7 +73,7 @@ export const POST: APIRoute = async ({ request }) => {
   const resend = new Resend(apiKey);
   const { error } = await resend.emails.send({
     from: "contact@h-ymt.dev",
-    to: ["glanz.web.creative@gmail.com"],
+    to: ["y.handai1272@gmail.com"],
     subject: `Contact from ${result.data.name}`,
     replyTo: result.data.email,
     text: `Name: ${result.data.name}\nEmail: ${result.data.email}\n\n${result.data.message}`,

--- a/src/pages/contact/index.astro
+++ b/src/pages/contact/index.astro
@@ -33,8 +33,19 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
         <label for="message" class="label">Message</label>
         <textarea id="message" name="message" class="textarea" rows="6" required></textarea>
       </div>
+      <div
+        class="cf-turnstile"
+        data-sitekey="0x4AAAAAADOGZc4W0EQsUR38"
+        data-theme="auto"
+      ></div>
       <button type="submit" id="submitBtn" class="button">Send</button>
     </form>
+
+    <script
+      src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+      async
+      defer
+    ></script>
   </Container>
 </BaseLayout>
 
@@ -64,10 +75,15 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
         successMessage.hidden = false;
         form.hidden = true;
       } else {
+        // @ts-ignore
+        if (window.turnstile) window.turnstile.reset();
+
         errorMessage.textContent = json.error ?? "Something went wrong. Please try again later.";
         errorMessage.hidden = false;
       }
     } catch {
+      // @ts-ignore
+      if (window.turnstile) window.turnstile.reset();
       errorMessage.textContent = "Something went wrong. Please try again later.";
       errorMessage.hidden = false;
     } finally {
@@ -99,12 +115,12 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
   }
 
   .message.success {
-    background: color-mix(in srgb, var(--foreground) 6%, transparent);
-    color: var(--foreground);
+    background: color-mix(in srgb, #22c55e 12%, transparent);
+    color: #16a34a;
   }
 
   .message.error {
-    background: color-mix(in srgb, #ef4444 10%, transparent);
+    background: color-mix(in srgb, #ef4444 12%, transparent);
     color: #dc2626;
   }
 

--- a/src/pages/contact/index.astro
+++ b/src/pages/contact/index.astro
@@ -1,0 +1,173 @@
+---
+import Container from "../../components/Container.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="Contact - Yamato Handai" description="Feel free to reach out via the contact form.">
+  <Container type="page">
+    <h1 class="pageTitle">Contact</h1>
+    <p class="pageDescription">Feel free to reach out. I'll get back to you as soon as possible.</p>
+
+    <div id="successMessage" class="message success" hidden>
+      Your message has been sent. Thank you for reaching out!
+    </div>
+    <div id="errorMessage" class="message error" hidden></div>
+
+    <form id="contactForm" class="form" novalidate>
+      <div class="field">
+        <label for="name" class="label">Name</label>
+        <input type="text" id="name" name="name" class="input" autocomplete="name" required />
+      </div>
+      <div class="field">
+        <label for="email" class="label">Email</label>
+        <input
+          type="email"
+          id="email"
+          name="email"
+          class="input"
+          autocomplete="email"
+          required
+        />
+      </div>
+      <div class="field">
+        <label for="message" class="label">Message</label>
+        <textarea id="message" name="message" class="textarea" rows="6" required></textarea>
+      </div>
+      <button type="submit" id="submitBtn" class="button">Send</button>
+    </form>
+  </Container>
+</BaseLayout>
+
+<script>
+  const form = document.getElementById("contactForm") as HTMLFormElement;
+  const submitBtn = document.getElementById("submitBtn") as HTMLButtonElement;
+  const successMessage = document.getElementById("successMessage") as HTMLElement;
+  const errorMessage = document.getElementById("errorMessage") as HTMLElement;
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+
+    successMessage.hidden = true;
+    errorMessage.hidden = true;
+    submitBtn.disabled = true;
+    submitBtn.textContent = "Sending...";
+
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        body: new FormData(form),
+      });
+
+      const json = await res.json();
+
+      if (json.success) {
+        successMessage.hidden = false;
+        form.hidden = true;
+      } else {
+        errorMessage.textContent = json.error ?? "Something went wrong. Please try again later.";
+        errorMessage.hidden = false;
+      }
+    } catch {
+      errorMessage.textContent = "Something went wrong. Please try again later.";
+      errorMessage.hidden = false;
+    } finally {
+      submitBtn.disabled = false;
+      submitBtn.textContent = "Send";
+    }
+  });
+</script>
+
+<style>
+  .pageTitle {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--foreground);
+  }
+
+  .pageDescription {
+    margin-block-start: 0.75rem;
+    font-size: 0.9375rem;
+    color: var(--foreground-muted);
+  }
+
+  .message {
+    max-width: 36rem;
+    margin-block-start: 1.5rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+  }
+
+  .message.success {
+    background: color-mix(in srgb, var(--foreground) 6%, transparent);
+    color: var(--foreground);
+  }
+
+  .message.error {
+    background: color-mix(in srgb, #ef4444 10%, transparent);
+    color: #dc2626;
+  }
+
+  .form {
+    display: grid;
+    gap: 1.5rem;
+    margin-block-start: 2.5rem;
+    max-width: 36rem;
+  }
+
+  .field {
+    display: grid;
+    gap: 0.375rem;
+  }
+
+  .label {
+    font-size: 0.875rem;
+    color: var(--foreground);
+  }
+
+  .input,
+  .textarea {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.9375rem;
+    font-family: inherit;
+    color: var(--foreground);
+    background: var(--background);
+    border: 0.0625rem solid var(--border);
+    border-radius: 0.375rem;
+    outline: none;
+    transition: border-color 0.15s;
+  }
+
+  .input:focus,
+  .textarea:focus {
+    border-color: var(--foreground-muted);
+  }
+
+  .textarea {
+    resize: vertical;
+    min-height: 8rem;
+  }
+
+  .button {
+    justify-self: start;
+    padding: 0.5rem 1.25rem;
+    font-size: 0.875rem;
+    font-family: inherit;
+    color: var(--background);
+    background: var(--foreground);
+    border: none;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+
+  .button:hover {
+    opacity: 0.8;
+  }
+
+  .button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>


### PR DESCRIPTION
## Summary

- Resend APIを使ったお問い合わせフォームを `/contact` に追加
- サーバーサイドバリデーション（必須チェック・メール形式チェック）
- fetch非同期送信によりページ遷移なしで成功/エラーメッセージを表示
- ナビゲーションに Contact リンクを追加

## Test plan

- [ ] `pnpm dev` で `localhost:4321/contact` を開いてフォームが表示されることを確認
- [ ] `.dev.vars` に `RESEND_API_KEY` を設定してメール送信が成功することを確認
- [ ] 空フォーム送信でエラーメッセージが表示されることを確認
- [ ] 不正なメールアドレスでエラーが返ることを確認
- [ ] 本番デプロイ前に `wrangler secret put RESEND_API_KEY` でSecretを登録

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* New contact page with a form for user inquiries
* Automatic email notifications when contact forms are submitted
* Added contact link to the main navigation menu

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/H-ymt/hymt/pull/43)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->