### PR TITLE
fix: Fetch Knowledge cronがCloudflare Workers環境で認証失敗する問題を修正

### DIFF
--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -7,4 +7,5 @@ interface CloudflareEnv {
   ZENN_USER?: string;
   RESEND_API_KEY?: string;
   TURNSTILE_SECRET_KEY?: string;
+  CRON_SECRET?: string;
 }

--- a/src/lib/utils/cloudflare.ts
+++ b/src/lib/utils/cloudflare.ts
@@ -12,6 +12,10 @@ export function getTurnstileSecretKey(): string | undefined {
   return (env as CloudflareEnv).TURNSTILE_SECRET_KEY;
 }
 
+export function getCronSecret(): string | undefined {
+  return (env as CloudflareEnv).CRON_SECRET;
+}
+
 export function getFetchKnowledgeEnv(): {
   GITHUB_USERNAME?: string;
   GITHUB_TOKEN?: string;

--- a/src/pages/api/fetch-knowledge.ts
+++ b/src/pages/api/fetch-knowledge.ts
@@ -1,11 +1,11 @@
 import type { APIRoute } from "astro";
 import { saveEntries } from "../../lib/data/entries";
 import { fetchKnowledgeEntries } from "../../lib/fetch-knowledge-worker";
-import { getFetchKnowledgeEnv, getKnowledgeKV } from "../../lib/utils/cloudflare";
+import { getCronSecret, getFetchKnowledgeEnv, getKnowledgeKV } from "../../lib/utils/cloudflare";
 
 export const POST: APIRoute = async ({ request }) => {
   const authHeader = request.headers.get("authorization");
-  const cronSecret = process.env.CRON_SECRET;
+  const cronSecret = getCronSecret();
 
   if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
     return new Response(JSON.stringify({ error: "Unauthorized" }), {


### PR DESCRIPTION
## Summary

* `fetch-knowledge` APIで `process.env.CRON_SECRET` を使っていたが、Cloudflare Workers環境では `process.env` にアクセスできず常に `undefined` になっていた
* `cloudflare:workers` の `env` オブジェクトから取得する `getCronSecret()` を追加し、他のシークレット取得パターンと統一
* `CloudflareEnv` 型定義に `CRON_SECRET` を追加

## Test plan

- [X] GitHub Actions の Fetch Knowledge ワークフローを手動実行して成功することを確認（修正後デプロイ済みで `success` を確認済み）